### PR TITLE
refactor: Adjust type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcellab/js-plugin-utils",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Utils for using the parcelLab js plugin with different frameworks (react/vue)",
   "private": false,
   "files": [

--- a/v3/react/index.d.ts
+++ b/v3/react/index.d.ts
@@ -2,7 +2,7 @@ declare module "@parcellab/js-plugin-utils/v3/react" {
   import type React from "react";
 
   interface PropsType {
-    options?: object;
+    options?: Record<string, unknown | never>;
     disableDefaultStyles?: boolean;
   }
 

--- a/v3/react/index.d.ts
+++ b/v3/react/index.d.ts
@@ -1,12 +1,12 @@
 declare module "@parcellab/js-plugin-utils/v3/react" {
   import type React from "react";
 
-  export interface PluginOptionsType {
+  interface PropsType {
     options?: object;
     disableDefaultStyles?: boolean;
   }
 
-  const TrackAndTrace: React.FC<PluginOptionsType>;
+  const TrackAndTrace: React.FC<PropsType>;
 
   export default TrackAndTrace;
 }

--- a/v3/vue/index.d.ts
+++ b/v3/vue/index.d.ts
@@ -2,7 +2,7 @@ declare module "@parcellab/js-plugin-utils/v3/vue" {
   import { defineComponent } from "vue";
 
   interface PropsType {
-    options?: object;
+    options?: Record<string, unknown | never>;
     disableDefaultStyles?: boolean;
   }
 

--- a/v3/vue/index.d.ts
+++ b/v3/vue/index.d.ts
@@ -1,10 +1,10 @@
 declare module "@parcellab/js-plugin-utils/v3/vue" {
   import { defineComponent } from "vue";
 
-  export interface PluginOptionsType {
+  interface PropsType {
     options?: object;
     disableDefaultStyles?: boolean;
   }
 
-  export default function (props: PluginOptionsType): ReturnType<typeof defineComponent>;
+  export default function (props: PropsType): ReturnType<typeof defineComponent>;
 }

--- a/v5/react/index.d.ts
+++ b/v5/react/index.d.ts
@@ -1,59 +1,61 @@
 declare module "@parcellab/js-plugin-utils/v5/react" {
   import type React from "react";
 
-  export interface PluginOptionsType {
-    options?: Partial<{
-      banner_image: string;
-      banner_link: string;
-      use_campaign_banners: boolean;
-      borderColor: string;
-      borderRadius: string;
-      buttonBackground: string;
-      buttonColor: string;
-      comingFromSearch: boolean;
-      disableVoting: boolean;
-      forceZip: boolean;
-      hide_cancelled: boolean;
-      icon_theme: "xmas" | "easter" | "";
-      iconColor: string;
-      iconSize: string;
-      liveMapBackground: string;
-      liveMapColor: string;
-      openinghrs_warn: string;
-      pwrdBy_parcelLab: boolean;
-      rerouteButton: string;
-      selectedTrackingNo: string;
-      show_articleList: boolean;
-      show_note: string;
-      show_searchForm: boolean;
-      show_zipCodeInput: boolean;
-      use_origin_courier: boolean;
-      splitOrderWarning: string;
-      tabIconColor: string;
-      activeTabIconColor: string;
-      disableStyleEditor: boolean;
-      courier: string;
-      id: string;
-      lang: string;
-      orderNo: string;
-      s: string;
-      trackingNo: string;
-      userId: string;
-      xid: string;
-      zip: string;
-      locale: string;
-      /* Learn more about the expected received args at https://how.parcellab.works/docs/order-status-page/configuration#onrendered-hook */
-      onRendered: (args: object) => void;
-      containerId: string;
-      customTranslations: {
-        /* Learn more about the expected syntax at https://how.parcellab.works/docs/order-status-page/configuration#onrendered-hook */
-        [language: string]: { [key: string]: unknown };
-      };
-    }>;
+  export type PluginOptionsType = Partial<{
+    banner_image: string;
+    banner_link: string;
+    use_campaign_banners: boolean;
+    borderColor: string;
+    borderRadius: string;
+    buttonBackground: string;
+    buttonColor: string;
+    comingFromSearch: boolean;
+    disableVoting: boolean;
+    forceZip: boolean;
+    hide_cancelled: boolean;
+    icon_theme: "xmas" | "easter" | "";
+    iconColor: string;
+    iconSize: string;
+    liveMapBackground: string;
+    liveMapColor: string;
+    openinghrs_warn: string;
+    pwrdBy_parcelLab: boolean;
+    rerouteButton: string;
+    selectedTrackingNo: string;
+    show_articleList: boolean;
+    show_note: string;
+    show_searchForm: boolean;
+    show_zipCodeInput: boolean;
+    use_origin_courier: boolean;
+    splitOrderWarning: string;
+    tabIconColor: string;
+    activeTabIconColor: string;
+    disableStyleEditor: boolean;
+    courier: string;
+    id: string;
+    lang: string;
+    orderNo: string;
+    s: string;
+    trackingNo: string;
+    userId: string;
+    xid: string;
+    zip: string;
+    locale: string;
+    /* Learn more about the expected received args at https://how.parcellab.works/docs/order-status-page/configuration#onrendered-hook */
+    onRendered: (args: object) => void;
+    containerId: string;
+    customTranslations: {
+      /* Learn more about the expected syntax at https://how.parcellab.works/docs/order-status-page/configuration#onrendered-hook */
+      [language: string]: { [key: string]: unknown };
+    };
+  }>;
+
+  interface PropsType {
+    options?: PluginOptionsType;
     disableDefaultStyles?: boolean;
   }
 
-  const TrackAndTrace: React.FC<PluginOptionsType>;
+  const TrackAndTrace: React.FC<PropsType>;
 
   export default TrackAndTrace;
 }

--- a/v5/vue/index.d.ts
+++ b/v5/vue/index.d.ts
@@ -1,57 +1,59 @@
 declare module "@parcellab/js-plugin-utils/v5/vue" {
   import { defineComponent } from "vue";
 
-  export interface PluginOptionsType {
-    options?: Partial<{
-      banner_image: string;
-      banner_link: string;
-      use_campaign_banners: boolean;
-      borderColor: string;
-      borderRadius: string;
-      buttonBackground: string;
-      buttonColor: string;
-      comingFromSearch: boolean;
-      disableVoting: boolean;
-      forceZip: boolean;
-      hide_cancelled: boolean;
-      icon_theme: "xmas" | "easter" | "";
-      iconColor: string;
-      iconSize: string;
-      liveMapBackground: string;
-      liveMapColor: string;
-      openinghrs_warn: string;
-      pwrdBy_parcelLab: boolean;
-      rerouteButton: string;
-      selectedTrackingNo: string;
-      show_articleList: boolean;
-      show_note: string;
-      show_searchForm: boolean;
-      show_zipCodeInput: boolean;
-      use_origin_courier: boolean;
-      splitOrderWarning: string;
-      tabIconColor: string;
-      activeTabIconColor: string;
-      disableStyleEditor: boolean;
-      courier: string;
-      id: string;
-      lang: string;
-      orderNo: string;
-      s: string;
-      trackingNo: string;
-      userId: string;
-      xid: string;
-      zip: string;
-      locale: string;
-      /* Learn more about the expected received args at https://how.parcellab.works/docs/order-status-page/configuration#onrendered-hook */
-      onRendered: (args: object) => void;
-      containerId: string;
-      customTranslations: {
-        /* Learn more about the expected syntax at https://how.parcellab.works/docs/order-status-page/configuration#onrendered-hook */
-        [language: string]: { [key: string]: unknown };
-      };
-    }>;
+  export type PluginOptionsType = Partial<{
+    banner_image: string;
+    banner_link: string;
+    use_campaign_banners: boolean;
+    borderColor: string;
+    borderRadius: string;
+    buttonBackground: string;
+    buttonColor: string;
+    comingFromSearch: boolean;
+    disableVoting: boolean;
+    forceZip: boolean;
+    hide_cancelled: boolean;
+    icon_theme: "xmas" | "easter" | "";
+    iconColor: string;
+    iconSize: string;
+    liveMapBackground: string;
+    liveMapColor: string;
+    openinghrs_warn: string;
+    pwrdBy_parcelLab: boolean;
+    rerouteButton: string;
+    selectedTrackingNo: string;
+    show_articleList: boolean;
+    show_note: string;
+    show_searchForm: boolean;
+    show_zipCodeInput: boolean;
+    use_origin_courier: boolean;
+    splitOrderWarning: string;
+    tabIconColor: string;
+    activeTabIconColor: string;
+    disableStyleEditor: boolean;
+    courier: string;
+    id: string;
+    lang: string;
+    orderNo: string;
+    s: string;
+    trackingNo: string;
+    userId: string;
+    xid: string;
+    zip: string;
+    locale: string;
+    /* Learn more about the expected received args at https://how.parcellab.works/docs/order-status-page/configuration#onrendered-hook */
+    onRendered: (args: object) => void;
+    containerId: string;
+    customTranslations: {
+      /* Learn more about the expected syntax at https://how.parcellab.works/docs/order-status-page/configuration#onrendered-hook */
+      [language: string]: { [key: string]: unknown };
+    };
+  }>;
+
+  interface PropsType {
+    options?: PluginOptionsType;
     disableDefaultStyles?: boolean;
   }
 
-  export default function (props: PluginOptionsType): ReturnType<typeof defineComponent>;
+  export default function (props: PropsType): ReturnType<typeof defineComponent>;
 }


### PR DESCRIPTION
## Description
- refactoring to export the pluginOptionsType directly
- restricting the type object in older versions to include only {key: values}


